### PR TITLE
Reduce CPU usage of CSS animation

### DIFF
--- a/schedule.html
+++ b/schedule.html
@@ -6,7 +6,7 @@
   <title>Eulerroom Equinox 2020</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body style="animation-iteration-count:1;">
   <div class="language-list">
     <ul>
       <li data-key="en"><a href="?lang=en">en</a></li>


### PR DESCRIPTION
This special override will stop the background animation and only play it through once. As this is a page visitors might leave open in the background, it's very energy wasteful to keep animating. By stopping the CSS after a bit (30sec) the CPU usage on this page drops from 20-30% down to ~0.3%.